### PR TITLE
(feat) add configurable loop count option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ blink_cursor = true
 user_name = "x0rzavi" # for prompt
 fps = 15
 color_scheme = "yoru"
+loop_count = 0 # infinite loop
 
 [files]
 frame_base_name = "frame_"

--- a/gifos/config/gifos_settings.toml
+++ b/gifos/config/gifos_settings.toml
@@ -6,6 +6,7 @@ blink_cursor = true
 user_name = "x0rzavi" # for prompt
 fps = 15
 color_scheme = "yoru"
+loop_count = 0 # infinite loop
 
 [files]
 frame_base_name = "frame_"


### PR DESCRIPTION
Adds a configurable `loop_count` property to the `gifos_settings.toml` and `gifos.py` Terminal class, with a setter function in the latter.

I had a bit of trouble trying to generate a non-looping gif with the library and ended up having to just yoink the call to ffmpeg from the `Terminal.gen_gif()` method and change it to add a `-loop` flag. 

From `ffmpeg -h muxer=gif` the loop count options are:
| \-loop arg | num loops     |
| ---------- | ------------- |
| \-1        | no loop       |
| 0          | infinite loop |
| 1..65535   | loop n times  |

with a default argument of `0`

Having the default as zero in both the configuration file as well as the terminal class should mean that default behaviour is unchanged. This is my first ever pull request so let me know if it needs changing or is just terrible.

Thank you for such a fun library!