### PR TITLE
fix bug - catch `ValueError`

### DIFF
--- a/gifos/utils/load_config.py
+++ b/gifos/utils/load_config.py
@@ -46,7 +46,7 @@ def load_toml(file_name: str) -> dict:
                             env_var_value = int(
                                 env_var_value
                             )  # convert string values to int
-                        except TypeError:
+                        except ValueError:
                             pass
                     config[key] = env_var_value
                     print(


### PR DESCRIPTION
https://github.com/x0rzavi/github-readme-terminal/issues/11

for this problem, ValueError is thrown when the int() conversion fails.